### PR TITLE
Add ability to specify command for compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var compassTree = compileSass(tree, files, {
 ```
 if `files` is omitted the entire folder will be compiled.
 
-### Options
+### Main Options
 
 #### `compassCommand`
 
@@ -30,6 +30,7 @@ Command to execute compass.
 
 **Default:** `compass`
 
+### Compass Options
 
 Please refere to the [compass configuration](http://compass-style.org/help/tutorials/configuration-reference/) for more details about the available options
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ CompassCompiler.prototype.write = function (readTree, destDir) {
   return readTree(this.inputTree).then(function (srcDir) {
     var cmdLine;
     var options = merge({}, self.options);
-    var cmdArgs = [options.compassCommand, 'compile', self.files]; //src is project dir or specifed files
+    var cmd = [options.compassCommand, 'compile'];
+    var cmdArgs = cmd.concat(self.files); //src is project dir or specifed files
     var cssDir = path.join(destDir, options.cssDir || '');
 
     delete options.compassCommand;


### PR DESCRIPTION
The `compassCommand` option allows for the user to specify how they want to
run compass. This means that the plugin can now run compass using bundler or a
non-PATH location to the compass executable.

<!---
@huboard:{"order":1.0,"custom_state":""}
-->
