### PR TITLE
Do not reprocess if input trees are not changed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "broccoli-writer": "^0.1.1",
     "rsvp": "^3.0.6",
-    "broccoli-static-compiler": "^0.1.4"
+    "broccoli-static-compiler": "^0.1.4",
+    "broccoli-caching-writer": "~0.3.1"
   }
 }


### PR DESCRIPTION
Currently, `Writer.prototype.write` is called every time any tree is invalidated. This results in a fairly significant performance issue (as shelling out is slow). `broccoli-caching-writer` will only call `updateCache` if the input trees have changed.
