### PR TITLE
Use new version of broccoli-caching-writer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-compass",
-  "version": "0.0.10",
+  "version": "0.0.9",
   "description": "Sass-compass plugin for Broccoli",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This version includes support for caching to filesystems that do not support symlinking, which is a problem that occurs when using shares on Virtualbox and VMWare Fusion.
