### PR TITLE
Make sure that the CachingWriter constructor is called.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var ignoredOptions = [
       'compassCommand',
       'ignoreErrors',
       'exclude',
-      'files'
+      'files',
+      'filterFromCache'
     ];
 
 //TODO: collect sass/scss on construct to build the list css generated files for copy.


### PR DESCRIPTION
Will be needed in order to be able to take advantage of recent/upcoming changes to broccoli-caching-writer (like https://github.com/rwjblue/broccoli-caching-writer/pull/11).
