### PR TITLE
Move rimraf to main dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "dargs": "^0.1.0",
     "merge": "^1.1.3",
     "quick-temp": "^0.1.2",
+    "rimraf": "^2.2.8",
     "rsvp": "^3.0.9",
     "symlink-or-copy": "^1.0.0"
   },
   "devDependencies": {
     "broccoli": "~0.12.3",
-    "expect.js": "^0.3.1",
-    "rimraf": "^2.2.8"
+    "expect.js": "^0.3.1"
   }
 }


### PR DESCRIPTION
It's required in `index.js`, which was throwing this error when I tried to use the package:

> Error: Cannot find module 'rimraf'
